### PR TITLE
Look for user icons in AccountsService directory too

### DIFF
--- a/src/widgets/user/user.cpp
+++ b/src/widgets/user/user.cpp
@@ -26,12 +26,17 @@
 
 static inline QString getIcon( QString name ) {
     QString iconPath = QString( "/home/%1/.face" ).arg( name );
-
-    QPixmap pix( QString( "/home/%1/.face" ).arg( name ) );
+    
+    QPixmap pix( iconPath );
 
     if ( pix.isNull() ) {
-        pix      = QPixmap( QString( "/home/%1/.face.icon" ).arg( name ) );
         iconPath = QString( "/home/%1/.face.icon" ).arg( name );
+        pix      = QPixmap( iconPath );
+    }
+
+    if ( pix.isNull() ) {
+        iconPath = QString( "/var/lib/AccountsService/icons/%1" ).arg( name );
+        pix      = QPixmap( iconPath );
     }
 
     if ( pix.isNull() ) {


### PR DESCRIPTION
Added ability to look for user icons in D-Bus AccountsService directory: `/var/lib/AccountsService/icons/<username>`.

Reasons:

- Users may not want their home directories readable by other users for security reasons, preventing QtGreet to read `.face` or `.face.icon` from this location.
- GNOME and possibly other desktop environments use the D-Bus AccountsService for managing user icons instead of `.face`.